### PR TITLE
Put query parameters in a predictable order

### DIFF
--- a/lib/URI/FromHash.pm
+++ b/lib/URI/FromHash.pm
@@ -12,14 +12,14 @@ use Exporter qw( import );
 our @EXPORT_OK = qw( uri uri_object );
 
 my %BaseParams = (
-    scheme   => { type => SCALAR,            optional => 1 },
-    username => { type => SCALAR,            optional => 1 },
-    password => { type => SCALAR,            default  => '' },
-    host     => { type => SCALAR,            optional => 1 },
-    port     => { type => SCALAR,            optional => 1 },
-    path     => { type => SCALAR | ARRAYREF, optional => 1 },
-    query    => { type => HASHREF,           default  => {} },
-    fragment => { type => SCALAR,            optional => 1 },
+    scheme   => { type => SCALAR, optional => 1 },
+    username => { type => SCALAR, optional => 1 },
+    password => { type => SCALAR, default  => '' },
+    host     => { type => SCALAR, optional => 1 },
+    port     => { type => SCALAR, optional => 1 },
+    path => { type => SCALAR | ARRAYREF, optional => 1 },
+    query    => { type => HASHREF, default  => {} },
+    fragment => { type => SCALAR,  optional => 1 },
 );
 
 sub uri_object {
@@ -57,8 +57,8 @@ sub uri_object {
         }
     }
 
-    while ( my ( $k, $v ) = each %{ $p{query} } ) {
-        $uri->query_param( $k => $v );
+    for my $param ( sort keys %{ $p{query} } ) {
+        $uri->query_param( $param => $p{query}{$param} );
     }
 
     $uri->fragment( $p{fragment} )

--- a/t/uri.t
+++ b/t/uri.t
@@ -45,7 +45,7 @@ use URI::FromHash qw( uri uri_object );
         'uri starts with http://example.com?'
     );
     like(
-        $uri, qr{\?(?:a=1;b=foo)|(?:b=foo;a=1)},
+        $uri, qr{\?(?:a=1;b=foo)},
         'contains expected query elements'
     );
 }
@@ -55,14 +55,14 @@ use URI::FromHash qw( uri uri_object );
         scheme          => 'http',
         host            => 'example.com',
         query           => { a => 1, b => 'foo' },
-        query_separator => '|',
+        query_separator => '&',
     );
     like(
         $uri, qr{^http://example.com\?},
         'uri starts with http://example.com?'
     );
     like(
-        $uri, qr{\?(?:a=1|b=foo)|(?:b=foo|a=1)},
+        $uri, qr{\?a=1&b=foo},
         'contains expected query elements'
     );
 }
@@ -108,7 +108,7 @@ use URI::FromHash qw( uri uri_object );
         query  => { a => [ 1, 2 ] },
     );
     like(
-        $uri, qr{\?(?:a=1;a=2)|(?:a=2;a=1)},
+        $uri, qr{\?a=1;a=2},
         'contains expected query elements'
     );
 }


### PR DESCRIPTION
Also fix broken separator test.

URI now does this if you use `->query_form` per [this PR](https://github.com/libwww-perl/uri/pull/18). I am not sure why this module uses `->query_param`.
